### PR TITLE
C++ Discord Hooking Code & Handling Windows Messages.

### DIFF
--- a/External/main.cpp
+++ b/External/main.cpp
@@ -1492,36 +1492,36 @@ void setupWindow() {
 }
 
 
-LRESULT CALLBACK WinProc(HWND hWnd, UINT Message, WPARAM wParam, LPARAM lParam)
+switch (Message)
 {
-	if (ImGui_ImplWin32_WndProcHandler(hWnd, Message, wParam, lParam))
-		return true;
-
-	switch (Message)
-	{
-	case WM_DESTROY:
-		CleanuoD3D();
-		PostQuitMessage(0);
-		exit(4);
-		break;
-	case WM_SIZE:
-		if (p_Device != NULL && wParam != SIZE_MINIMIZED)
-		{
-			ImGui_ImplDX9_InvalidateDeviceObjects();
-			p_Params.BackBufferWidth = LOWORD(lParam);
-			p_Params.BackBufferHeight = HIWORD(lParam);
-			HRESULT hr = p_Device->Reset(&p_Params);
-			if (hr == D3DERR_INVALIDCALL)
-				IM_ASSERT(0);
-			MessageBox(0, L"Failed to find valid trampoline", L"Failure", 0);
-		}
-		break;
-	default:
-		return DefWindowProc(hWnd, Message, wParam, lParam);
-		break;
-	}
-	return 0;
+case WM_DESTROY:
+    CleanupD3D();
+    PostQuitMessage(0);
+    break;
+case WM_SIZE:
+    if (p_Device != NULL && wParam != SIZE_MINIMIZED)
+    {
+        ImGui_ImplDX9_InvalidateDeviceObjects();
+        p_Params.BackBufferWidth = LOWORD(lParam);
+        p_Params.BackBufferHeight = HIWORD(lParam);
+        HRESULT hr = p_Device->Reset(&p_Params);
+        if (hr == D3DERR_INVALIDCALL)
+        {
+            MessageBox(0, L"Failed to reset Direct3D device", L"Error", MB_ICONERROR);
+            PostQuitMessage(0);
+        }
+        else
+        {
+            ImGui_ImplDX9_CreateDeviceObjects();
+        }
+    }
+    break;
+default:
+    return DefWindowProc(hWnd, Message, wParam, lParam);
 }
+
+return 0;
+
 
 void SetWindowToTarget()
 {

--- a/External/registry.cpp
+++ b/External/registry.cpp
@@ -219,18 +219,13 @@ UINT pscStartSlot;
 ID3D11Buffer *mConstantBuffers;
 UINT vsConstant_StartSlot;
 
-UINT psStartSlot;
-UINT vsStartSlot;
+UINT psStartSlot = 0, vsStartSlot = 0;
 
+const auto pcall_present_discord = Helper::PatternScan(Discord::GetDiscordModuleBase(), "FF 15 ? ? ? ? 8B D8 E8 ? ? ? ? E8 ? ? ? ? EB 10");
 
-	const auto pcall_present_discord = Helper::PatternScan(Discord::GetDiscordModuleBase(), xorstr("FF 15 ? ? ? ? 8B D8 E8 ? ? ? ? E8 ? ? ? ? EB 10"));
-	auto presentSceneAdress = Helper::PatternScan(Discord::GetDiscordModuleBase(),
-		xorstr("56 57 53 48 83 EC 30 44 89 C6"));
+const auto presentSceneAdress = Helper::PatternScan(Discord::GetDiscordModuleBase(), "56 57 53 48 83 EC 30 44 89 C6");
 
-	DISCORD.HookFunction(presentSceneAdress, (uintptr_t)PresentHook, (uintptr_t)&PresentOriginal);
+DISCORD.HookFunction(presentSceneAdress, reinterpret_cast<uintptr_t>(PresentHook), reinterpret_cast<uintptr_t>(&PresentOriginal));
 
-	DISCORD.HookFunction(presentSceneAdress, (uintptr_t)ResizeHook, (uintptr_t)&PresentOriginal);
-	{
-		
-	return true;
-};
+DISCORD.HookFunction(presentSceneAdress, reinterpret_cast<uintptr_t>(ResizeHook), reinterpret_cast<uintptr_t>(&PresentOriginal));
+


### PR DESCRIPTION
It's possible to make the code shorter, but it's important to keep in mind that shorter code is not always better.

In some cases, shorter code can be harder to understand, harder to maintain, and less efficient than longer, more explicit code. It's important to prioritize readability, maintainability, and efficiency over brevity.


That being said, here's a possible way to make the code shorter by using inline initialization for the two UINT variables:

