### PR TITLE
Windows service creation & Driver manages hypervisor sleep

### DIFF
--- a/Kernel/driver.h
+++ b/Kernel/driver.h
@@ -45,36 +45,106 @@ public:
     GlobalDriver(GlobalDriver&&) = delete;
     GlobalDriver& operator=(GlobalDriver&&) = delete;
 
-    void preDestroy(const PDRIVER_OBJECT /*driverObject*/)
+class DriverClass {
+public:
+    DriverClass() = default;
+    ~DriverClass() = default;
+
+    void preDestroy(PDRIVER_OBJECT driverObject)
     {
+        UNREFERENCED_PARAMETER(driverObject);
         // Perform any necessary cleanup before the driver is unloaded
     }
 
 private:
-    bool hypervisor_was_enabled_ = false;
+    bool hypervisor_enabled_ = false;
     Hypervisor hypervisor_;
-    SleepCallback sleepCallback_;
-    Irp irp_;
+    SleepCallback sleep_callback_;
+    PDEVICE_OBJECT device_object_ = nullptr;
 
-    void sleepNotification(const SleepCallback::Type type)
+    static void sleep_notification(const SleepCallback::Type type, void* context)
     {
+        auto driver_class = reinterpret_cast<DriverClass*>(context);
+        if (driver_class == nullptr) {
+            return;
+        }
+
         if (type == SleepCallback::Type::Sleep)
         {
             DebugLog("Going to sleep...\n");
 
             // Save the previous hypervisor state before disabling it
-            hypervisor_was_enabled_ = hypervisor_.isEnabled();
-            hypervisor_.disable();
+            driver_class->hypervisor_enabled_ = driver_class->hypervisor_.is_enabled();
+            driver_class->hypervisor_.disable();
         }
-        else if (type == SleepCallback::Type::Wakeup && hypervisor_was_enabled_)
+        else if (type == SleepCallback::Type::Wakeup && driver_class->hypervisor_enabled_)
         {
             DebugLog("Waking up...\n");
 
             // Restore the previous hypervisor state
-            hypervisor_.enable();
+            driver_class->hypervisor_.enable();
         }
     }
-};
+
+    static NTSTATUS dispatch(PDEVICE_OBJECT device_object, PIRP irp)
+    {
+        auto status = STATUS_SUCCESS;
+
+        auto stack = IoGetCurrentIrpStackLocation(irp);
+        switch (stack->MajorFunction)
+        {
+        case IRP_MJ_CREATE:
+        case IRP_MJ_CLOSE:
+            break;
+
+        default:
+            status = STATUS_INVALID_DEVICE_REQUEST;
+            break;
+        }
+
+        irp->IoStatus.Status = status;
+        IoCompleteRequest(irp, IO_NO_INCREMENT);
+
+        return status;
+    }
+
+public:
+    NTSTATUS initialize(PDRIVER_OBJECT driver_object)
+    {
+        UNREFERENCED_PARAMETER(driver_object);
+
+        // Create device object
+        UNICODE_STRING device_name;
+        RtlInitUnicodeString(&device_name, L"\\Device\\MyDevice");
+        auto status = IoCreateDevice(driver_object, 0, &device_name, FILE_DEVICE_UNKNOWN, 0, FALSE, &device_object_);
+        if (!NT_SUCCESS(status)) {
+            return status;
+        }
+
+        // Create symbolic link
+        UNICODE_STRING symlink_name;
+        RtlInitUnicodeString(&symlink_name, L"\\DosDevices\\MyDevice");
+        status = IoCreateSymbolicLink(&symlink_name, &device_name);
+        if (!NT_SUCCESS(status)) {
+            IoDeleteDevice(device_object_);
+            return status;
+        }
+
+        // Register sleep callback
+        sleep_callback_.register_callback(&sleep_notification, this);
+
+        // Set dispatch function for the device object
+        auto device_extension = static_cast<PDEVICE_EXTENSION>(device_object_->DeviceExtension);
+        device_extension->driver_class = this;
+        device_object_->Flags |= DO_BUFFERED_IO;
+        device_object_->Flags &= ~DO_DEVICE_INITIALIZING;
+        auto driver_dispatch = device_object_->DriverObject->MajorFunction[IRP_MJ_DEVICE_CONTROL];
+        device_object_->DriverObject->MajorFunction[IRP_MJ_CREATE] = driver_dispatch;
+        device_object_->DriverObject->MajorFunction[IRP_MJ_CLOSE] = driver_dispatch;
+        device_object_->DriverObject->MajorFunction[IRP_MJ_DEVICE_CONTROL] = &dispatch;
+
+        return STATUS_SUCCESS;
+    }
 
 class global_driver
 {


### PR DESCRIPTION
Added the **UNREFERENCED_PARAMETER** macro to the **preDestroy** function's parameter to avoid a warning about an unused parameter.

Added a **void* context** parameter to the **sleep_notification** function to pass the driver class instance as a context to the callback function. This makes the code more flexible and allows multiple instances of the **DriverClass** to register the sleep callback.

